### PR TITLE
Add missing license to gemspec, is MIT

### DIFF
--- a/sucker_punch.gemspec
+++ b/sucker_punch.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q{Asynchronous processing library for Ruby}
   gem.summary       = %q{Sucker Punch is a Ruby asynchronous processing using Celluloid, heavily influenced by Sidekiq and girl_friday.}
   gem.homepage      = "https://github.com/brandonhilkert/sucker_punch"
+  gem.license       = "MIT"
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
See 
- https://github.com/bf4/gemproject/issues/1
- http://guides.rubygems.org/specification-reference/#license=
- http://www.benjaminfleischer.com/2013/07/12/make-the-world-a-better-place-put-a-license-in-your-gemspec/
