### PR TITLE
Fix inheritance monkey patch

### DIFF
--- a/lib/sucker_punch/testing/inline.rb
+++ b/lib/sucker_punch/testing/inline.rb
@@ -1,7 +1,12 @@
+require "celluloid/proxies/abstract_proxy"
+require "celluloid/proxies/sync_proxy"
+require "celluloid/proxies/actor_proxy"
+
 module Celluloid
-  class ActorProxy
+  class ActorProxy < SyncProxy
     def async(method_name = nil, *args, &block)
       self
     end
   end
 end
+


### PR DESCRIPTION
- ActorProxy inherits from SyncProxy, so when testing, I got:
  "TypeError: superclass mismatch for class ActorProxy"

I don't know why tests were passing without this, however.
