### PR TITLE
provide access to celluloid's exception handler

### DIFF
--- a/lib/sucker_punch.rb
+++ b/lib/sucker_punch.rb
@@ -12,6 +12,10 @@ module SuckerPunch
   def self.logger=(logger)
     Celluloid.logger = logger
   end
+
+  def self.exception_handler(&block)
+  	Celluloid.exception_handler(&block)
+  end
 end
 
 require 'sucker_punch/railtie' if defined?(::Rails)

--- a/rails_app_example/app/controllers/jobs_controller.rb
+++ b/rails_app_example/app/controllers/jobs_controller.rb
@@ -1,6 +1,12 @@
 class JobsController < ApplicationController
   def index
     @store = STORE
+    @crashes = CRASHES
+  end
+
+  def crashing
+    CrashingJob.new.async.perform
+    redirect_to jobs_path
   end
 
   def single

--- a/rails_app_example/app/jobs/crashing_job.rb
+++ b/rails_app_example/app/jobs/crashing_job.rb
@@ -1,0 +1,9 @@
+class CrashingJob
+  include SuckerPunch::Job
+  workers 4
+
+  def perform
+    raise 'Oooops, I just crashed'
+  end
+end
+

--- a/rails_app_example/app/views/jobs/index.html.erb
+++ b/rails_app_example/app/views/jobs/index.html.erb
@@ -5,6 +5,11 @@
 <% end %>
 
 <br />
+<%= form_tag crashing_jobs_path do %>
+  <%= submit_tag "Add 1 crashing job to store" %>
+<% end %>
+
+<br />
 <%= form_tag multiple_jobs_path do %>
   <%= submit_tag "Add 1 job to store every 1 second for 5 seconds" %>
 <% end %>
@@ -12,8 +17,24 @@
 
 <h2>Store Content</h2>
 <p>
-<% @store.each do |item| %>
-  <%= item %>
-  <br />
+<% if @store.any? %>
+  <% @store.each do |item| %>
+    <%= item %>
+    <br />
+  <% end %>
+<% else %>
+  (nothing)
+<% end %>
+</p>
+
+<h2>Crashes</h2>
+<p>
+<% if @crashes.any? %>
+  <% @crashes.each do |item| %>
+    <%= item %>
+    <br />
+  <% end %>
+<% else %>
+  (none)
 <% end %>
 </p>

--- a/rails_app_example/config/initializers/store.rb
+++ b/rails_app_example/config/initializers/store.rb
@@ -1,1 +1,4 @@
 STORE = []
+CRASHES = []
+
+SuckerPunch.exception_handler { |ex| CRASHES << ex }

--- a/rails_app_example/config/routes.rb
+++ b/rails_app_example/config/routes.rb
@@ -2,6 +2,7 @@ Myapp::Application.routes.draw do
   root "jobs#index"
 
   resources :jobs, only: [:index] do
+    post :crashing, on: :collection
     post :single, on: :collection
     post :multiple, on: :collection
   end


### PR DESCRIPTION
Hi Brandon, this pull request adds access to celluloid's exception handler so that one can use his own - just the way one can use his own logger. To visualize this I added an exception handler to the example_app, that saves exceptions in an array called CRASHES (similar to the STORE array). The contents of this array is shown in the view and you can also "add a crashing job" with a button.
