### PR TITLE
Remove Travis hack for rbx-2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,3 @@ matrix:
   allow_failures:
     - rvm: jruby-19mode
     - rvm: rbx-2
-  global:
-    - BUNDLE_JOBS=4
-before_install:
-  # Only use 1 job until Travis fixes the rbx --jobs issue.
-  - if [ "$TRAVIS_RUBY_VERSION" == "rbx-2" ] ; then export BUNDLE_JOBS=1 ; fi
-install: bundle install --retry=3


### PR DESCRIPTION
With travis-ci/travis-ci#2952 we no longer need this hack.
