### PR TITLE
Define String#underscore if it's not already defined

### DIFF
--- a/lib/sucker_punch/core_ext.rb
+++ b/lib/sucker_punch/core_ext.rb
@@ -5,5 +5,5 @@ class String
     gsub(/([a-z\d])([A-Z])/,'\1_\2').
     tr("-", "_").
     downcase
-  end
-end if !defined?(::ActiveSupport) && !"".respond_to?(:underscore)
+  end if !"".respond_to?(:underscore)
+end


### PR DESCRIPTION
The ActiveSupport condition is overkill, since AS would have already
defined String#underscore.

I ran into this issue when using Sucker Punch in a Sinatra project.
