### PR TITLE
Don't clear non-SuckerPunch actors from registry

### DIFF
--- a/lib/sucker_punch.rb
+++ b/lib/sucker_punch.rb
@@ -16,6 +16,10 @@ module SuckerPunch
   def self.exception_handler(&block)
     Celluloid.exception_handler(&block)
   end
+
+  def self.clear_queues
+    SuckerPunch::Queue.clear_all
+  end
 end
 
 require 'sucker_punch/railtie' if defined?(::Rails)

--- a/lib/sucker_punch/queue.rb
+++ b/lib/sucker_punch/queue.rb
@@ -6,12 +6,24 @@ module SuckerPunch
     attr_accessor :pool
 
     DEFAULT_OPTIONS = { workers: 2 }
+    PREFIX = "sucker_punch"
     class MaxWorkersExceeded < StandardError; end
     class NotEnoughWorkers < StandardError; end
 
     def self.find(klass)
       queue = self.new(klass)
       Celluloid::Actor[queue.name]
+    end
+
+    def self.clear_all
+      Celluloid::Actor.all.each do |actor|
+        registered_name = actor.registered_name.to_s
+        matches = registered_name.match(PREFIX).to_a
+
+        if matches.any?
+          Celluloid::Actor.delete(registered_name)
+        end
+      end
     end
 
     def initialize(klass)
@@ -39,7 +51,8 @@ module SuckerPunch
     end
 
     def name
-      klass.to_s.underscore.to_sym
+      klass_name = klass.to_s.underscore
+      "#{PREFIX}_#{klass_name}".to_sym
     end
 
     private

--- a/lib/sucker_punch/railtie.rb
+++ b/lib/sucker_punch/railtie.rb
@@ -5,7 +5,7 @@ module SuckerPunch
     end
 
     config.to_prepare do
-      Celluloid::Actor.clear_registry
+      SuckerPunch.clear_queues
     end
   end
 end

--- a/spec/sucker_punch/queue_spec.rb
+++ b/spec/sucker_punch/queue_spec.rb
@@ -15,11 +15,37 @@ describe SuckerPunch::Queue do
     Celluloid::Actor.clear_registry
   end
 
-  describe "#find" do
+  describe ".find" do
     it "returns the Celluloid Actor from the registry" do
       SuckerPunch::Queue.new(FakeJob).register
       queue = SuckerPunch::Queue.find(FakeJob)
       queue.class == Celluloid::PoolManager
+    end
+  end
+
+  describe ".clear_all" do
+   it "removes SuckerPunch actors from Celluloid registry" do
+     sucker_punch_actor_name = "#{SuckerPunch::Queue::PREFIX}_fake_job".to_sym
+     Celluloid::Actor[sucker_punch_actor_name] = FakeJob.new
+
+     SuckerPunch::Queue.clear_all
+
+     expect(Celluloid::Actor[sucker_punch_actor_name]).to be_nil
+   end
+
+    it "does not remove non-SuckerPunch actors from Celluloid registry" do
+      class ::OtherJob
+        include ::Celluloid
+        def self.pool(options); end
+        def perform; end
+      end
+      actor_name = :other_job
+      job = OtherJob.new
+      Celluloid::Actor[actor_name] = job
+
+      SuckerPunch::Queue.clear_all
+
+      expect(Celluloid::Actor[actor_name]).to eq job
     end
   end
 
@@ -33,13 +59,19 @@ describe SuckerPunch::Queue do
     end
 
     it "registers the pool with Celluloid" do
+      expected_pool_name = "#{SuckerPunch::Queue::PREFIX}_fake_job".to_sym
+
       pool = queue.register
-      expect(Celluloid::Actor[:fake_job]).to eq(pool)
+
+      expect(Celluloid::Actor[expected_pool_name]).to eq(pool)
     end
 
     it "registers the pool with Celluloid and 3 workers" do
-      pool = queue.register(3)
-      expect(Celluloid::Actor[:fake_job].size).to eq(3)
+      expected_pool_name = "#{SuckerPunch::Queue::PREFIX}_fake_job"
+
+      queue.register(3)
+
+      expect(Celluloid::Actor[expected_pool_name].size).to eq(3)
     end
 
     context "when too many workers are specified" do

--- a/spec/sucker_punch_spec.rb
+++ b/spec/sucker_punch_spec.rb
@@ -11,4 +11,14 @@ describe SuckerPunch do
       SuckerPunch.logger = nil
     end
   end
+
+  describe '.clear_queues' do
+    it "clears SuckerPunch queues" do
+      allow(SuckerPunch::Queue).to receive(:clear_all)
+
+      SuckerPunch.clear_queues
+
+      expect(SuckerPunch::Queue).to have_received(:clear_all)
+    end
+  end
 end


### PR DESCRIPTION
* Currently `SuckerPunch::Railtie` clears all actors from the Celluloid
  actor registry during initialization. This is problematic because an
  application using SuckerPunch may have additional Celluloid actors.
* In this commit I propose prefixing the names of SuckerPunch
  actors such that we can ensure the Celluloid registry is cleared only
  of SuckerPunch actors on application initialization, per @nullstyle's
  suggestion here: https://github.com/brandonhilkert/sucker_punch/issues/99
* Update `SuckerPunch::Queue#name` to add a prefix to queue names
* Introduce `SuckerPunch.clear_actors`
* Update `SuckerPunch::Railtie` to use `SuckerPunch.clear_actors`