### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Full job data can be reported like this:
 ```Ruby
 def perform(all, my, arguments)
   ... your code ...
-rescue Exception
+rescue StandardError
   Airbrake.error($!, [self.class.name, all, my, arguments].inspect)
   raise
 end


### PR DESCRIPTION
Rescue StandardError in example, not Exception
http://daniel.fone.net.nz/blog/2013/05/28/why-you-should-never-rescue-exception-in-ruby/