### PR TITLE
Don't stop thread pool on at_exit

### DIFF
--- a/lib/sucker_punch/queue.rb
+++ b/lib/sucker_punch/queue.rb
@@ -13,8 +13,9 @@ module SuckerPunch
     def self.find_or_create(name, num_workers = 2)
       QUEUES.fetch_or_store(name) do
         options = DEFAULT_EXECUTOR_OPTIONS.merge({
-          min_threads: num_workers,
-          max_threads: num_workers
+          min_threads: 0,
+          max_threads: num_workers,
+          auto_terminate: false
         })
         Concurrent::ThreadPoolExecutor.new(options)
       end


### PR DESCRIPTION
Concurrent-ruby's ThreadPoolExecutor is automatically terminating pool on app exit [[doc](https://ruby-concurrency.github.io/concurrent-ruby/Concurrent/ThreadPoolExecutor.html)], to prevent this default changed `auto_terminate` to `false`.
Also set `min_threads` to 0 to create new threads just when need (handled by concurrent)
Fixes https://github.com/brandonhilkert/sucker_punch/issues/143