### PR TITLE
Better thread pool shutdown in tests.

### DIFF
--- a/lib/sucker_punch/queue.rb
+++ b/lib/sucker_punch/queue.rb
@@ -36,10 +36,13 @@ module SuckerPunch
     end
 
     def self.clear
+      # susceptible to race conditions--only use in testing
+      old = all
       QUEUES.clear
       SuckerPunch::Counter::Busy.clear
       SuckerPunch::Counter::Processed.clear
       SuckerPunch::Counter::Failed.clear
+      old.each { |queue| queue.kill }
     end
 
     def self.stats

--- a/test/sucker_punch/async_syntax_test.rb
+++ b/test/sucker_punch/async_syntax_test.rb
@@ -4,6 +4,11 @@ module SuckerPunch
   class AsyncSyntaxTest < Minitest::Test
     def setup
       require 'sucker_punch/async_syntax'
+      SuckerPunch::Queue.clear
+    end
+
+    def teardown
+      SuckerPunch::Queue.clear
     end
 
     def test_perform_async_runs_job_asynchronously

--- a/test/sucker_punch/counter_test.rb
+++ b/test/sucker_punch/counter_test.rb
@@ -4,9 +4,11 @@ module SuckerPunch
   class CounterTest < Minitest::Test
     def setup
       @queue = "fake"
+      SuckerPunch::Queue.clear
     end
 
     def teardown
+      SuckerPunch::Queue.clear
       SuckerPunch::Counter::Busy.clear
       SuckerPunch::Counter::Failed.clear
       SuckerPunch::Counter::Processed.clear

--- a/test/sucker_punch/job_test.rb
+++ b/test/sucker_punch/job_test.rb
@@ -2,6 +2,10 @@ require 'test_helper'
 
 module SuckerPunch
   class JobTest < Minitest::Test
+    def setup
+      SuckerPunch::Queue.clear
+    end
+
     def teardown
       SuckerPunch::Queue.clear
       SuckerPunch::RUNNING.make_true

--- a/test/sucker_punch_test.rb
+++ b/test/sucker_punch_test.rb
@@ -1,7 +1,12 @@
 require 'test_helper'
 
 class SuckerPunchTest < Minitest::Test
+  def setup
+    SuckerPunch::Queue.clear
+  end
+
   def teardown
+    SuckerPunch::Queue.clear
     SuckerPunch.logger = nil
     SuckerPunch.exception_handler = nil
   end


### PR DESCRIPTION
There may be a more elegant way to handle this, but I think it will solve the problem of non-terminating thread pools in tests on JRuby.

* Manually kill all queues when the `Queue.clear` is called
* Clear all queues during setup and teardown for all tests
