### PR TITLE
Fixes a small timing bug during shutdown.

### DIFF
--- a/lib/sucker_punch.rb
+++ b/lib/sucker_punch.rb
@@ -56,6 +56,7 @@ module SuckerPunch
 
         queues.each do |queue|
           queue.post(latch) { |l| l.count_down }
+          queue.shutdown
         end
 
         if latch.wait(8) # 10 seconds on heroku, minus a grace period

--- a/lib/sucker_punch/job.rb
+++ b/lib/sucker_punch/job.rb
@@ -30,15 +30,14 @@ module SuckerPunch
 
     module ClassMethods
       def perform_async(*args)
+        return unless SuckerPunch::RUNNING.true?
         queue = SuckerPunch::Queue.find_or_create(self.to_s, num_workers)
-        # will return false if the queue is shutting down
         queue.post(args) { |args| __run_perform(*args) }
       end
 
       def perform_in(interval, *args)
+        return unless SuckerPunch::RUNNING.true?
         queue = SuckerPunch::Queue.find_or_create(self.to_s, num_workers)
-        return unless queue.running?
-        # if the queue is shutdown before interval the job won't run
         job = Concurrent::ScheduledTask.execute(interval.to_f, args: args, executor: queue) do
           __run_perform(*args)
         end


### PR DESCRIPTION
There was a small race condition in the previous implementation. This race condition did *not* result in bugs given the current shutdown algorithm. However, it could lead to subtle bugs should that algorithm change. This PR imposes a small performance penalty on every job post to a queue but it is the most "correct" approach.

The first issue is that I forgot to shutdown the queues in the previous implementation. The second issue is that I removed the `SuckerPunch::RUNNING.true?` check from the `perform_*` methods. The former was an oversight and should be fixed. The latter is a deliberate performance optimization that may be unnecessary.

The missing `#shutdown` call (added on line 59 of `sucker_punch.rb`) prevents any new jobs from being post to the thread pool and ensures proper thread pool shutdown. Without this line there may be shutdown problems on JRuby, which won't shutdown the JVM with running thread pools. On MRI this is less of an issue since MRI doesn't care. I consider this change to be necessary--it's a bug.

I consider the `SuckerPunch::RUNNING.true?` check in the `perform_async` and `perform_in` methods to be optional. They are necessary for "correctness" but impose a small performance penalty. Without these checks there is a small possibility that jobs may sneak in before an individual queue is shutdown. With the current algorithm that isn't a problem. The `__run_perform` function checks the flag again and skips any jobs that may have slipped in. Thus the intended shutdown behavior is preserved. Should the check in `__run_perform` be removed or changed to support a different algorithm (say, to let all enqueued jobs finish) then we have a  timing bug. Adding the new checks in the two `perform_*` methods does not allow us to remove the check in `__run_perform`, however. The latter check is used for clearing the queue during shutdown. It must stay.

Adding the `SuckerPunch::RUNNING.true?` checks to the `perform_*` methods adds a tiny bit of latency to every job. `Concurrent::AtomicBoolean` is pretty fast but the time for the check is not zero. So we have a performance vs. correctness tradeoff. I personally prefer correctness but I wanted the tradeoff to be known.

As a side note, those on MRI who are performance conscious should consider installing the optional [C extensions](https://github.com/ruby-concurrency/concurrent-ruby#c-extensions-for-mri). It contains a pure-C version of `AtomicBoolean` that will automatically be loaded if detected (no code changes are necessary--users simply need to install the gem). The cost of the `SuckerPunch::RUNNING.true?` check will be significantly less if concurrent-ruby-ext is installed. There is a [benchmark script](https://github.com/ruby-concurrency/concurrent-ruby/blob/master/examples/benchmark_atomic_boolean.rb) that will show the difference.