### PR TITLE
Greater determinism on Job tests

### DIFF
--- a/test/sucker_punch/job_test.rb
+++ b/test/sucker_punch/job_test.rb
@@ -15,7 +15,7 @@ module SuckerPunch
       arr = Concurrent::Array.new
       latch = Concurrent::CountDownLatch.new
       FakeLatchJob.perform_async(arr, latch)
-      latch.wait(0.2)
+      latch.wait(1)
       assert_equal 1, arr.size
     end
 
@@ -32,7 +32,7 @@ module SuckerPunch
       arr = Concurrent::Array.new
       latch = Concurrent::CountDownLatch.new
       FakeLatchJob.perform_in(0.1, arr, latch)
-      latch.wait(0.2)
+      latch.wait(1)
       assert_equal 1, arr.size
     end
 
@@ -94,14 +94,14 @@ module SuckerPunch
       2.times{ FakeLogJob.perform_async }
       queue = SuckerPunch::Queue.find_or_create(FakeLogJob.to_s)
       queue.post { latch.count_down }
-      latch.wait(0.2)
+      latch.wait(1)
       assert SuckerPunch::Counter::Processed.new(FakeLogJob.to_s).value > 0
     end
 
     def test_processed_jobs_is_incremented_when_enqueued_with_perform_in
       latch = Concurrent::CountDownLatch.new
       FakeLatchJob.perform_in(0.1, [], latch)
-      latch.wait(0.2)
+      latch.wait(1)
       assert SuckerPunch::Counter::Processed.new(FakeLatchJob.to_s).value > 0
     end
 
@@ -110,7 +110,7 @@ module SuckerPunch
       2.times{ FakeErrorJob.perform_async }
       queue = SuckerPunch::Queue.find_or_create(FakeErrorJob.to_s)
       queue.post { latch.count_down }
-      latch.wait(0.2)
+      latch.wait(1)
       assert SuckerPunch::Counter::Failed.new(FakeErrorJob.to_s).value > 0
     end
 


### PR DESCRIPTION
See #152 

I've submit this PR as two commits in case you don't like the second of the two. It changes the nature of the testing in a way you may not like.

The first commit increases the latch wait time from 0.2 seconds to 1.0 seconds on many tests. Ruby isn't a systems language so it's timers are horribly inaccurate. Additionally, the free Travis service runs the tests on very slow machines. In my experience a 0.1 second wait simply isn't enough. (Trust me on this, I've written/debugged more concurrency tests than most Rubyists! :-) ) It is impossible to make some of these tests 100% deterministic so the best we can hope for is very close. The 1.0 second wait won't slow down the tests when they pass (the latch waits the minimum time necessary) but it will reduce the possibility of false negatives. 1.0 seconds is my go-to for tests like this in c-r.

The second commit shifts a few tests to immediate (synchronous) execution. This makes these tests 100% deterministic, but it shifts some responsibility to c-r. It makes the assumption that c-r does what we promise it does and then only tests the behavior of sucker_punch.

Passing a timeout value of less than 0.1 seconds to `Concurrent::ScheduledTask` causes the task to be immediately post to the thread pool (see my comments about Ruby inaccurate timers above).

`Concurrent::ImmediateExecutor` is a fake thread pool that we use extensively for testing. It supports the full set of method calls that real thread pool expose but it runs jobs immediately on the current thread. It's part of our public API so it's safe to use--it won't go away and its API will always match that of our thread pools.

Depending on how you feel about the stubbing I've added, the `test_perform_in_runs_job_in_future` could use the same stubbing approach as well. The timing checks I've added should make it less susceptible to false negatives, but it's really testing c-r. I think it would be fine to trust that `ScheduledTask` does what we say it does and in your test simply assert that the job is post.