### PR TITLE
Update CHANGES.md

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,7 +22,7 @@
     ```
 
 - Drop support for Ruby `< 2.0`
-- Allow shutdown timeout to be set (default is 10 sec.):
+- Allow shutdown timeout to be set (default is 8 sec.):
 
     ```ruby
     SuckerPunch.shutdown_timeout = 15 # time in seconds


### PR DESCRIPTION
The timeout is actually 8 seconds, not 10. :)

I think a few more notes for the migration would be nice in the changelog, too, but I don't know all of them. Only stuff like the adapter for Rails < 5.0.0.