### PR TITLE
Fix docs on location of active_job config

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,11 +270,11 @@ gem 'sucker_punch'
 And then configure the backend to use Sucker Punch:
 
 ```Ruby
-# config/initializers/sucker_punch.rb
-Rails.application.configure do
+# config/application.rb
+class Application < Rails::Application
+  # ...
   config.active_job.queue_adapter = :sucker_punch
 end
-
 ```
 
 If you want to use Sucker Punch version `2.0.0+` with Rails `< 5.0.0`, be sure


### PR DESCRIPTION
With `activejob 4.2.6` and `sucker_punch 1.4`, the `active_job.queue_adapter` won't get picked up by ActiveJob if it's in an initializer. It needs to be in `application.rb`.