### PR TITLE
[skip ci] Remove extra blank from template using the generator

### DIFF
--- a/lib/generators/sucker_punch/templates/job.rb
+++ b/lib/generators/sucker_punch/templates/job.rb
@@ -1,6 +1,6 @@
-class <%= class_name %>Job 
+class <%= class_name %>Job
   include SuckerPunch::Job
-  
+
   def perform
     raise NotImplementedError
   end


### PR DESCRIPTION
This PR removes the extra blank of the template using the generator.

<img width="227" alt="screen shot 2016-09-24 at 4 20 37 pm" src="https://cloud.githubusercontent.com/assets/6765108/18811012/fead13fe-8272-11e6-970f-999bddbc56ac.png">
