### PR TITLE
fix warning: instance variable @shutdown_timeout not initialized

### DIFF
--- a/lib/sucker_punch.rb
+++ b/lib/sucker_punch.rb
@@ -39,9 +39,9 @@ module SuckerPunch
       l
     end
 
-    def shutdown_timeout
+    def shutdown_timeout  
       # 10 seconds on heroku, minus a grace period
-      @shutdown_timeout || 8
+      @shutdown_timeout ||= 8
     end
 
     def shutdown_timeout=(timeout)


### PR DESCRIPTION
Warning shows every time I run rspec on my apps.