### PR TITLE
Include Sinatra specific instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,19 @@ $ rails g sucker_punch:job logger
 would create the file `app/jobs/logger_job.rb` with a unimplemented `#perform`
 method.
 
+## Sinatra
+
+If you're using Sucker Punch with Sinatra, you must require Sucker Punch before Sinatra:
+
+```ruby
+# app.rb
+
+require 'sucker_punch'
+require 'sinatra'
+```
+
+This will ensure Sucker Punch's `at_exit()` handler to clean up and shutdown queues does not happen **before** Sinatra *starts up* via its own `at_exit()` handler.
+
 ## Active Job
 
 Sucker Punch has been added as an Active Job adapter in Rails 4.2.


### PR DESCRIPTION
Sinatra (starts itself)[https://github.com/sinatra/sinatra/blob/master/lib/sinatra/main.rb#L26] up in an `at_exit()` handler.  Ruby runs multiple `at_exit()` handlers in reverse order of registration.  Sucker Punch does clean up and shutdown in an `at_exit()` handler.  Hence, if SuckerPunch is required *after* Sinatra, Sucker Punch will shut itself down just prior to Sinatra starting up.  

This is a bit surprising, so mention it in the docs.