### PR TITLE
Adding queue options to Job so that you can set the max_queue value.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,26 @@
+2.1.0
+-------
+- Add max\_jobs configuration option to set the maximum number of tasks that 
+  may be waiting in the work queue
+
+    ```ruby
+    class JobWithLimit
+      include SuckerPunch::Job
+      max_jobs 2
+
+      def perform(data)
+        # work...
+      end
+    end
+
+    10.times do
+      begin
+        JobWithLimit.perform_async('work') }
+      rescue Concurrent::RejectedExecutionError => e
+        # Queue maxed out, this job didn't get queued
+      end
+    end
+
 2.0.4
 -------
 - Better initialization of variables and names to remove warnings

--- a/README.md
+++ b/README.md
@@ -116,13 +116,13 @@ end
 
 #### Configure the Queue Size
 
-The default queue size is unlimited. If you wish to restrict this you can supply
-queue options as follows:
+The default number of jobs that can be queued is unlimited. If you wish to restrict this you can set
+maximum\_jobs as follows:
 
 ```Ruby
 class LogJob
   include SuckerPunch::Job
-  queue_options max_queue: 10
+  maximum_jobs 10
 
   def perform(event)
     Log.new(event).track

--- a/README.md
+++ b/README.md
@@ -114,6 +114,22 @@ class LogJob
 end
 ```
 
+#### Configure the Queue Size
+
+The default queue size is unlimited. If you wish to restrict this you can supply
+queue options as follows:
+
+```Ruby
+class LogJob
+  include SuckerPunch::Job
+  queue_options max_queue: 10
+
+  def perform(event)
+    Log.new(event).track
+  end
+end
+```
+
 #### Executing Jobs in the Future
 
 Many background processing libraries have methods to perform operations after a

--- a/README.md
+++ b/README.md
@@ -117,12 +117,12 @@ end
 #### Configure the Queue Size
 
 The default number of jobs that can be queued is unlimited. If you wish to restrict this you can set
-maximum\_jobs as follows:
+max\_jobs as follows:
 
 ```Ruby
 class LogJob
   include SuckerPunch::Job
-  maximum_jobs 10
+  max_jobs 10
 
   def perform(event)
     Log.new(event).track

--- a/lib/sucker_punch/job.rb
+++ b/lib/sucker_punch/job.rb
@@ -21,10 +21,10 @@ module SuckerPunch
     def self.included(base)
       base.extend(ClassMethods)
       base.class_attribute :num_workers
-      base.class_attribute :max_jobs
+      base.class_attribute :num_jobs_max
 
       base.num_workers = 2
-      base.max_jobs = nil
+      base.num_jobs_max = nil
     end
 
     def logger
@@ -34,13 +34,13 @@ module SuckerPunch
     module ClassMethods
       def perform_async(*args)
         return unless SuckerPunch::RUNNING.true?
-        queue = SuckerPunch::Queue.find_or_create(self.to_s, num_workers, max_jobs)
+        queue = SuckerPunch::Queue.find_or_create(self.to_s, num_workers, num_jobs_max)
         queue.post(args) { |job_args| __run_perform(*job_args) }
       end
 
       def perform_in(interval, *args)
         return unless SuckerPunch::RUNNING.true?
-        queue = SuckerPunch::Queue.find_or_create(self.to_s, num_workers, max_jobs)
+        queue = SuckerPunch::Queue.find_or_create(self.to_s, num_workers, num_jobs_max)
         job = Concurrent::ScheduledTask.execute(interval.to_f, args: args, executor: queue) do
           __run_perform(*args)
         end
@@ -51,8 +51,8 @@ module SuckerPunch
         self.num_workers = num
       end
 
-      def maximum_jobs(num)
-        self.max_jobs = num
+      def max_jobs(num)
+        self.num_jobs_max = num
       end
 
       def __run_perform(*args)

--- a/lib/sucker_punch/job.rb
+++ b/lib/sucker_punch/job.rb
@@ -21,8 +21,10 @@ module SuckerPunch
     def self.included(base)
       base.extend(ClassMethods)
       base.class_attribute :num_workers
+      base.class_attribute :queue_opts
 
       base.num_workers = 2
+      base.queue_opts = {}
     end
 
     def logger
@@ -32,13 +34,13 @@ module SuckerPunch
     module ClassMethods
       def perform_async(*args)
         return unless SuckerPunch::RUNNING.true?
-        queue = SuckerPunch::Queue.find_or_create(self.to_s, num_workers)
+        queue = SuckerPunch::Queue.find_or_create(self.to_s, num_workers, queue_opts)
         queue.post(args) { |job_args| __run_perform(*job_args) }
       end
 
       def perform_in(interval, *args)
         return unless SuckerPunch::RUNNING.true?
-        queue = SuckerPunch::Queue.find_or_create(self.to_s, num_workers)
+        queue = SuckerPunch::Queue.find_or_create(self.to_s, num_workers, queue_opts)
         job = Concurrent::ScheduledTask.execute(interval.to_f, args: args, executor: queue) do
           __run_perform(*args)
         end
@@ -47,6 +49,10 @@ module SuckerPunch
 
       def workers(num)
         self.num_workers = num
+      end
+
+      def queue_options(opts)
+        self.queue_opts = opts
       end
 
       def __run_perform(*args)

--- a/lib/sucker_punch/queue.rb
+++ b/lib/sucker_punch/queue.rb
@@ -16,13 +16,13 @@ module SuckerPunch
 
     QUEUES = Concurrent::Map.new
 
-    def self.find_or_create(name, num_workers = 2, max_jobs = nil)
+    def self.find_or_create(name, num_workers = 2, num_jobs_max = nil)
       pool = QUEUES.fetch_or_store(name) do
         options = DEFAULT_EXECUTOR_OPTIONS
           .merge(
             min_threads: num_workers,
             max_threads: num_workers,
-            max_queue: max_jobs || DEFAULT_MAX_QUEUE_SIZE
+            max_queue: num_jobs_max || DEFAULT_MAX_QUEUE_SIZE
           )
         Concurrent::ThreadPoolExecutor.new(options)
       end

--- a/lib/sucker_punch/queue.rb
+++ b/lib/sucker_punch/queue.rb
@@ -11,20 +11,19 @@ module SuckerPunch
       min_threads:     2,
       max_threads:     2,
       idletime:        60, # 1 minute
-      max_queue:       DEFAULT_MAX_QUEUE_SIZE,
       auto_terminate:  false # Let shutdown modes handle thread termination
     }.freeze
 
     QUEUES = Concurrent::Map.new
 
-    def self.find_or_create(name, num_workers = 2, opts = {})
+    def self.find_or_create(name, num_workers = 2, max_jobs = nil)
       pool = QUEUES.fetch_or_store(name) do
         options = DEFAULT_EXECUTOR_OPTIONS
           .merge(
             min_threads: num_workers,
-            max_threads: num_workers
+            max_threads: num_workers,
+            max_queue: max_jobs || DEFAULT_MAX_QUEUE_SIZE
           )
-          .merge(opts)
         Concurrent::ThreadPoolExecutor.new(options)
       end
 

--- a/test/sucker_punch/job_test.rb
+++ b/test/sucker_punch/job_test.rb
@@ -55,9 +55,9 @@ module SuckerPunch
       FakeLogJob.workers(2)
     end
 
-    def test_can_set_queue_options
-      FakeLogJob.queue_options(max_queue: 10)
-      assert_equal({ max_queue: 10 }, FakeLogJob.queue_opts)
+    def test_can_set_max_jobs
+      FakeLogJob.maximum_jobs(10)
+      assert_equal 10, FakeLogJob.max_jobs
     end
 
     def test_logger_is_accessible_from_instance

--- a/test/sucker_punch/job_test.rb
+++ b/test/sucker_punch/job_test.rb
@@ -56,8 +56,8 @@ module SuckerPunch
     end
 
     def test_can_set_max_jobs
-      FakeLogJob.maximum_jobs(10)
-      assert_equal 10, FakeLogJob.max_jobs
+      FakeLogJob.max_jobs(10)
+      assert_equal 10, FakeLogJob.num_jobs_max
     end
 
     def test_logger_is_accessible_from_instance

--- a/test/sucker_punch/job_test.rb
+++ b/test/sucker_punch/job_test.rb
@@ -55,6 +55,11 @@ module SuckerPunch
       FakeLogJob.workers(2)
     end
 
+    def test_can_set_queue_options
+      FakeLogJob.queue_options(max_queue: 10)
+      assert_equal({ max_queue: 10 }, FakeLogJob.queue_opts)
+    end
+
     def test_logger_is_accessible_from_instance
       SuckerPunch.logger = SuckerPunch.default_logger
       assert_equal SuckerPunch.logger, FakeLogJob.new.logger

--- a/test/sucker_punch/queue_test.rb
+++ b/test/sucker_punch/queue_test.rb
@@ -29,8 +29,8 @@ module SuckerPunch
       assert_equal 4, queue.min_length
     end
 
-    def test_queue_queue_options_can_be_set
-      queue = SuckerPunch::Queue.find_or_create(@queue, 4, max_queue: 10)
+    def test_queue_max_queue_can_be_set
+      queue = SuckerPunch::Queue.find_or_create(@queue, 4, 10)
       assert_equal(10, queue.max_queue)
     end
 

--- a/test/sucker_punch/queue_test.rb
+++ b/test/sucker_punch/queue_test.rb
@@ -29,6 +29,11 @@ module SuckerPunch
       assert_equal 4, queue.min_length
     end
 
+    def test_queue_queue_options_can_be_set
+      queue = SuckerPunch::Queue.find_or_create(@queue, 4, max_queue: 10)
+      assert_equal(10, queue.max_queue)
+    end
+
     def test_same_queue_is_returned_on_subsequent_queries
       queue = SuckerPunch::Queue.find_or_create(@queue)
       assert_equal queue, SuckerPunch::Queue.find_or_create(@queue)


### PR DESCRIPTION
We were evaluating Sucker Punch and found that we wanted to restrict the size of the queue for jobs instead of having unlimited as the normal setting.

I've tried to follow the style used for options already in Job, while remaining backward compatible.

If there's a reason for fixing the queue size to unlimited, feel free to reject this PR.

Otherwise happy to make any changes requested if you'd like to add this feature.