### PR TITLE
Add rubygems metadata

### DIFF
--- a/sucker_punch.gemspec
+++ b/sucker_punch.gemspec
@@ -25,4 +25,10 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "pry"
 
   gem.add_dependency "concurrent-ruby", "~> 1.0"
+  
+  if gem.respond_to?(:metadata)
+    gem.metadata['changelog_uri'] = 'https://github.com/brandonhilkert/sucker_punch/blob/master/CHANGES.md'
+    gem.metadata['source_code_uri'] = 'https://github.com/brandonhilkert/sucker_punch'
+    gem.metadata['bug_tracker_uri'] = 'https://github.com/brandonhilkert/sucker_punch/issues'
+  end
 end


### PR DESCRIPTION
Add urls which will appear as direct links on rubygems listing. This helps with automated info collection and manual searching for the right place.