### PR TITLE
Use ruby_2_keywords to handle keyword arguments

### DIFF
--- a/lib/sucker_punch/async_syntax.rb
+++ b/lib/sucker_punch/async_syntax.rb
@@ -13,6 +13,7 @@ module SuckerPunch
     def perform(*args)
       @job.class.perform_async(*args)
     end
+    ruby2_keywords(:perform) if respond_to?(:ruby2_keywords, true)
   end
 end
 

--- a/lib/sucker_punch/job.rb
+++ b/lib/sucker_punch/job.rb
@@ -37,6 +37,7 @@ module SuckerPunch
         queue = SuckerPunch::Queue.find_or_create(self.to_s, num_workers, num_jobs_max)
         queue.post(args) { |job_args| __run_perform(*job_args) }
       end
+      ruby2_keywords(:perform_async) if respond_to?(:ruby2_keywords, true)
 
       def perform_in(interval, *args)
         return unless SuckerPunch::RUNNING.true?
@@ -46,6 +47,7 @@ module SuckerPunch
         end
         job.pending?
       end
+      ruby2_keywords(:perform_in) if respond_to?(:ruby2_keywords, true)
 
       def workers(num)
         self.num_workers = num
@@ -66,6 +68,7 @@ module SuckerPunch
       ensure
         SuckerPunch::Counter::Busy.new(self.to_s).decrement
       end
+      ruby2_keywords(:__run_perform) if respond_to?(:ruby2_keywords)
     end
   end
 end

--- a/lib/sucker_punch/job.rb
+++ b/lib/sucker_punch/job.rb
@@ -68,7 +68,7 @@ module SuckerPunch
       ensure
         SuckerPunch::Counter::Busy.new(self.to_s).decrement
       end
-      ruby2_keywords(:__run_perform) if respond_to?(:ruby2_keywords)
+      ruby2_keywords(:__run_perform) if respond_to?(:ruby2_keywords, true)
     end
   end
 end

--- a/lib/sucker_punch/queue.rb
+++ b/lib/sucker_punch/queue.rb
@@ -174,6 +174,7 @@ module SuckerPunch
         end
       end
     end
+    ruby2_keywords(:post) if respond_to?(:ruby2_keywords, true)
 
     def kill
       @pool.kill

--- a/lib/sucker_punch/testing/inline.rb
+++ b/lib/sucker_punch/testing/inline.rb
@@ -28,10 +28,12 @@ module SuckerPunch
       def perform_async(*args)
         self.new.perform(*args)
       end
+      ruby2_keywords(:perform_async) if respond_to?(:ruby2_keywords, true)
 
       def perform_in(_, *args)
         self.new.perform(*args)
       end
+      ruby2_keywords(:perform_in) if respond_to?(:ruby2_keywords, true)
     end
   end
 end

--- a/test/sucker_punch/async_syntax_test.rb
+++ b/test/sucker_punch/async_syntax_test.rb
@@ -19,12 +19,29 @@ module SuckerPunch
       assert_equal 1, arr.size
     end
 
+    def test_perform_async_works_with_keywords
+      arr = Concurrent::Array.new
+      latch = Concurrent::CountDownLatch.new
+      FakeKeywordLatchJob.new.async.perform(arr: arr, latch: latch)
+      latch.wait(0.2)
+      assert_equal 1, arr.size
+    end
+
     private
 
     class FakeLatchJob
       include SuckerPunch::Job
 
       def perform(arr, latch)
+        arr.push true
+        latch.count_down
+      end
+    end
+
+    class FakeKeywordLatchJob
+      include SuckerPunch::Job
+
+      def perform(arr: Concurrent::Array.new, latch: Concurrent::CountDownLatch.new)
         arr.push true
         latch.count_down
       end

--- a/test/sucker_punch/queue_test.rb
+++ b/test/sucker_punch/queue_test.rb
@@ -100,6 +100,14 @@ module SuckerPunch
       assert_equal [1, 2], arr.first
     end
 
+    def test_jobs_can_be_posted_to_pool_with_keyword_args
+      arr = []
+      fake_pool = FakePool.new
+      queue     = SuckerPunch::Queue.new "fake", fake_pool
+      queue.post(a: 1, b: 2) { |args| arr.push args }
+      assert_equal [{a: 1, b: 2}], arr.first
+    end
+
     def test_kill_sends_kill_to_pool
       fake_pool = FakePool.new
       queue     = SuckerPunch::Queue.new "fake", fake_pool


### PR DESCRIPTION
Alternate solution for #234 

I think #235 is also a great solution and happy for that to be used instead.

Per https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/, this method should offer support back to Ruby 2.0.  [This was the method used for rspec](https://github.com/rspec/rspec-mocks/pull/1407/files) which requires ruby support back to 1.8 

