### PR TITLE
Test with Ruby 2.0-3.0, TruffleRuby, remove rbx-2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,21 @@
 language: ruby
+
+cache: bundler
+
 rvm:
-  - rbx-2
-  - 2.0.0
-  - 2.1.8
-  - 2.2.4
-  - 2.3.4
-  - 2.4.1
+  - truffleruby
+  - 2.0
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
+  - 3.0
   - ruby-head
 
 matrix:
   allow_failures:
-    - rvm: rbx-2
+    - rvm: truffleruby
+    - rvm: ruby-head


### PR DESCRIPTION
These are some opinionated changes, but I thought I'd start a discussion with this PR if necessary. I thought we might also set `required_ruby_version` in the `.gemspec` file, WDYT?

Edit: It seems Travis CI has been "disconnected" from GitHub, possibly due to inactivity. The current build is here: https://travis-ci.org/github/brandonhilkert/sucker_punch/builds/759174730 but maybe we can reactivate the build status for PRs?