### PR TITLE
Change CI badge from travis to GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sucker Punch
 
-[![Build Status](https://travis-ci.org/brandonhilkert/sucker_punch.svg?branch=master)](https://travis-ci.org/brandonhilkert/sucker_punch)
+[![Build](https://github.com/brandonhilkert/sucker_punch/actions/workflows/build.yml/badge.svg)](https://github.com/brandonhilkert/sucker_punch/actions/workflows/build.yml)
 [![Code Climate](https://codeclimate.com/github/brandonhilkert/sucker_punch.svg)](https://codeclimate.com/github/brandonhilkert/sucker_punch)
 
 Sucker Punch is a single-process Ruby asynchronous processing library.


### PR DESCRIPTION
It looks like the gem doesn't use TravisCI anymore.
The badge in README still points to Travis, so it should be changed to GitHub Actions badge.