### PR TITLE
Wait for queues to be idle.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+3.1.0
+-------
+- Add a blocking `SuckerPunch::Queue.wait` which waits for all queues to become idle.
+
 3.0.1
 -------
 - Opt for keyword parsing using `ruby2_keywords` for compatibility.

--- a/README.md
+++ b/README.md
@@ -243,6 +243,15 @@ To configure something other than the default 8 sec.:
   SuckerPunch.shutdown_timeout = 15 # # of sec. to wait before killing threads
 ```
 
+#### Queue Class Methods
+
+Sucker Punch leverages concurrent-friendly queues per-process. These class methods operating on all queues might be helpful in some edge cases.
+
+- `SuckerPunch::Queue.stats` - Returns a hash keyed by each queue's name with total, busy, and timeout statistics for each queue's `workers` and `jobs`.
+- `SuckerPunch::Queue.clear` - Calls `clear` for each queue. Susceptible to race conditions. Only use in testing.
+- `SuckerPunch::Queue.shutdown_all` - Used with SuckerPunch's `at_exit` hook. Waits for all queues to be idle using the [shutdown timeout](#shutdown-timeout) configuration above.
+- `SuckerPunch::Queue.wait` - Waits for all queues to become idle with no timeout. 
+
 #### Timeouts
 
 Using `Timeout` causes persistent connections to

--- a/lib/sucker_punch/queue.rb
+++ b/lib/sucker_punch/queue.rb
@@ -108,6 +108,19 @@ module SuckerPunch
         queues.each { |queue| queue.kill }
       end
     end
+    
+    def self.wait
+      queues = all
+      
+      # return if every queue is empty and workers in every queue are idle
+      return if queues.all? { |queue| queue.idle? }
+
+      SuckerPunch.logger.info("Pausing to allow workers to finish...")
+
+      while queues.any? { |queue| !queue.idle? }
+        sleep PAUSE_TIME
+      end
+    end
 
     attr_reader :name
 

--- a/lib/sucker_punch/version.rb
+++ b/lib/sucker_punch/version.rb
@@ -1,3 +1,3 @@
 module SuckerPunch
-  VERSION = "3.0.1"
+  VERSION = "3.1.0"
 end


### PR DESCRIPTION
Followup from discussion in #250. Some background on this feature. At Custom Ink we are exploring migrating our "messaging" and "jobs" pods from K8s to Lambda Containers. We can do this using the same ECR images in our deploy pipeline leveraging internal tools and perhaps one day Amazon Controller for Kubernetes (ACK). Sounds complicated but at the end of the day we use the same ECR images on Lambda by changing the ENTRYPOINT and COMMAND. The result would be Rails application processes that respond to AMQP/EventBridge events and/or Sidekiq style jobs using managed AWS Resources and scale to 0 Compute without writing custom software or changing code per-runtime. 

There are a few gotchas. Because AWS Lambda freezes the execution [freezes the execution environment](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtime-environment.html) between requests, background processing by long running processes typically break down. A good example is NewRelic. Thankfully, they have an interface to flush the metric data. For Rails projects that are 100% on AWS Lambda, we use a SuckerPunch inspired gem called LambdaPunch. https://github.com/customink/lambda_punch

Would LambdaPunch work here? It totally could. But it would be another extension we would have to install in the container and require a bit more orchestration in things like our Rollbar config. It would also require a lot of event handling delegation code to to pass down the Lambda context. Ideally, it would be awesome if SuckerPunch had a flush/wait interface similar to NewRelic. So the proposed change would appear like this to us.

```ruby
class MyJob < ApplicationJob
  after_perform do |_job| 
    NewRelic::Agent.agent.flush_pipe_data
    SuckerPunch::Queue.wait
  end

  def perform(event)
    # ...
  end
end
```

## More On The Topic

In case you are curious, here is one open source project that leans into a mantra I call (container code need not care where containers are running) that helps AWS Lambda mimic encrypted environment variables using AWS Systems Manager which K8s secrets manager does.

https://github.com/customink/crypteia

This helps ensure container portability with no code changes and leans into twelve factor. This is not directly related to the pull request but thought it might be helpful to share since we are asking for an interface that SuckerPunch (free puppy) vs implementing an internal gem or per-project freedom patches. I hope this context is helpful. 

## Pull Request Next Steps

I did not see any tests for `shutdown_all` so added none here. I would totally be willing to add some tho using your feedback? Also, is the method name right? Should it be `wait_all` or something different?